### PR TITLE
Bug 1763427 - Set rfc3161 certReq to True

### DIFF
--- a/src/winsign/timestamp.py
+++ b/src/winsign/timestamp.py
@@ -30,7 +30,7 @@ class TimeStampReq(univ.Sequence):
         namedtype.NamedType("messageImprint", DigestInfo()),
         namedtype.OptionalNamedType("reqPolicy", TSAPolicyId()),
         namedtype.OptionalNamedType("nonce", univ.Integer()),
-        namedtype.NamedType("certReq", univ.Boolean(False)),
+        namedtype.NamedType("certReq", univ.Boolean(True)),
         namedtype.OptionalNamedType(
             "extensions",
             univ.Any().subtype(

--- a/src/winsign/timestamp.py
+++ b/src/winsign/timestamp.py
@@ -30,7 +30,7 @@ class TimeStampReq(univ.Sequence):
         namedtype.NamedType("messageImprint", DigestInfo()),
         namedtype.OptionalNamedType("reqPolicy", TSAPolicyId()),
         namedtype.OptionalNamedType("nonce", univ.Integer()),
-        namedtype.NamedType("certReq", univ.Boolean(True)),
+        namedtype.NamedType("certReq", univ.Boolean(False)),
         namedtype.OptionalNamedType(
             "extensions",
             univ.Any().subtype(
@@ -91,6 +91,7 @@ async def get_rfc3161_timestamp(digest_algo, message, timestamp_url=None):
     req = TimeStampReq()
     req["messageImprint"]["digestAlgorithm"] = asn_digest_algo
     req["messageImprint"]["digest"] = hashlib.new(digest_algo, message).digest()
+    req["certReq"] = True
     encoded_req = der_encode(req)
 
     url = timestamp_url or "http://timestamp.digicert.com"


### PR DESCRIPTION
Resolves #22 

My recent experiments with rfc3161 timestamps reproduced the behaviour noted in the issue. Let's change this, deploy, and re-run the rfc3161 adhoc signing experiment.